### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,12 @@
 {
   "name": "Import videos by URLs from txt file",
   "type": "app",
-  "categories": ["import", "videos"],
+  "categories": [
+    "import",
+    "videos"
+  ],
   "description": "Downloads videos by URLs and uploads them to Supervisely Storage",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
@@ -19,7 +22,9 @@
   "icon": "https://i.imgur.com/iJvQXPJ.png",
   "icon_background": "#FFFFFF",
   "context_menu": {
-    "target": ["files_file"]
+    "target": [
+      "files_file"
+    ]
   },
   "poster": "https://user-images.githubusercontent.com/106374579/182794225-97ee531e-2d68-4654-9f18-83a68b3f3efe.png"
 }

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "categories": ["import", "videos"],
   "description": "Downloads videos by URLs and uploads them to Supervisely Storage",
   "docker_image": "supervisely/import-export:6.73.564",
-  "min_instance_version": "6.10.0",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["import", "videos"],
   "description": "Downloads videos by URLs and uploads them to Supervisely Storage",
-  "docker_image": "supervisely/import-export:6.73.158",
+  "docker_image": "supervisely/import-export:6.73.564",
   "min_instance_version": "6.10.0",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.158
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
